### PR TITLE
Handle network glitches [QA-156]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
 		</dependency>
 
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime_2.12</artifactId>
+			<version>1.12.0</version>
+		</dependency>
+
 
 		<!-- Jetty HTTP Client -->
 		<dependency>

--- a/src/main/java/com/persado/oss/quality/stevia/annotations/AnnotationsHelper.java
+++ b/src/main/java/com/persado/oss/quality/stevia/annotations/AnnotationsHelper.java
@@ -42,6 +42,8 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
@@ -145,7 +147,7 @@ public class AnnotationsHelper implements ApplicationContextAware {
 	 * mask existing controller with requestedControllerClass
 	 * @param requestedControllerClass
 	 */
-	private void controllerMask(Class<? extends WebController> requestedControllerClass) {
+	private void controllerMask(Class<? extends WebController> requestedControllerClass) throws InterruptedException, ExecutionException, TimeoutException {
 		WebController currentControllerObj = SteviaContext.getWebController();
 		Class<? extends WebController> currentControllerClass = currentControllerObj.getClass();
 		String curControllerKey = currentControllerClass.getCanonicalName();

--- a/src/main/java/com/persado/oss/quality/stevia/selenium/core/SteviaContextParameters.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/core/SteviaContextParameters.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.selenium.core;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *
+ *  
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ *  
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *
+ *  
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
+ *  
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *
+ *  
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE

--- a/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/SteviaWebControllerFactory.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/SteviaWebControllerFactory.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.selenium.core.controllers;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *  
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
+ *
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -36,61 +36,61 @@ package com.persado.oss.quality.stevia.selenium.core.controllers;
  * #L%
  */
 
-import java.net.MalformedURLException;
-import java.util.Map.Entry;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.context.ApplicationContext;
-import org.springframework.util.Assert;
-
 import com.persado.oss.quality.stevia.selenium.core.Constants;
 import com.persado.oss.quality.stevia.selenium.core.SteviaContext;
 import com.persado.oss.quality.stevia.selenium.core.WebController;
 import com.persado.oss.quality.stevia.selenium.core.controllers.factories.WebControllerFactory;
 import com.persado.oss.quality.stevia.selenium.core.controllers.registry.DriverRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.Assert;
+
+import java.net.MalformedURLException;
+import java.util.Map.Entry;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 
 public final class SteviaWebControllerFactory implements Constants {
 
-	public static final Logger LOG = LoggerFactory.getLogger(SteviaWebControllerFactory.class);
+    public static final Logger LOG = LoggerFactory.getLogger(SteviaWebControllerFactory.class);
 
-	public static WebController getWebController(ApplicationContext context) throws MalformedURLException {
-		WebController controller = null;
-		
-		String driverType = SteviaContext.getParam(DRIVER_TYPE);
-		
-		@SuppressWarnings("unchecked")
-		DriverRegistry<String, WebControllerFactory> registry  = (DriverRegistry<String, WebControllerFactory>)context.getBean("steviaDriverRegistry");
-		
-		WebControllerFactory factory = registry.getMappings().get(driverType);
-		Assert.notNull(factory,"Cannot find a factory for "+driverType);
-		
-		controller = (WebController) context.getBean(factory.getBeanName());
-		factory.initialize(context, controller);
-		return controller;
-	}
+    public static WebController getWebController(ApplicationContext context) throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+        WebController controller = null;
 
-	public static WebController getWebController(ApplicationContext context, Class<? extends WebController> requestedControllerClass) {
-		WebController controller = context.getBean(requestedControllerClass);
-		String[] namesForType = context.getBeanNamesForType(requestedControllerClass);
-		Assert.isTrue(namesForType.length == 1, 
-				"The requested controller "+requestedControllerClass.getName()+" is mapped with more than one names in the spring context!");
-		
-		@SuppressWarnings("unchecked")
-		DriverRegistry<String, WebControllerFactory> registry  = (DriverRegistry<String, WebControllerFactory>)context.getBean("steviaDriverRegistry");
-		
-		
-		for (Entry<String, WebControllerFactory> entry :  registry.getMappings().entrySet()) {
-			if (entry.getValue().getBeanName().equalsIgnoreCase(namesForType[0])) {
-				LOG.info("Factory from class detected : {}",entry.getKey());
-				WebControllerFactory factory = entry.getValue();
-				factory.initialize(context, controller);
-				return controller;
-			}
-		}
-		throw new IllegalStateException("Could not locate a factory for controller "+requestedControllerClass.getName()+" in this spring context!");
-	}
+        String driverType = SteviaContext.getParam(DRIVER_TYPE);
 
-   
+        @SuppressWarnings("unchecked")
+        DriverRegistry<String, WebControllerFactory> registry = (DriverRegistry<String, WebControllerFactory>) context.getBean("steviaDriverRegistry");
+
+        WebControllerFactory factory = registry.getMappings().get(driverType);
+        Assert.notNull(factory, "Cannot find a factory for " + driverType);
+
+        controller = (WebController) context.getBean(factory.getBeanName());
+        factory.initialize(context, controller);
+        return controller;
+    }
+
+    public static WebController getWebController(ApplicationContext context, Class<? extends WebController> requestedControllerClass) throws InterruptedException, ExecutionException, TimeoutException {
+        WebController controller = context.getBean(requestedControllerClass);
+        String[] namesForType = context.getBeanNamesForType(requestedControllerClass);
+        Assert.isTrue(namesForType.length == 1,
+                "The requested controller " + requestedControllerClass.getName() + " is mapped with more than one names in the spring context!");
+
+        @SuppressWarnings("unchecked")
+        DriverRegistry<String, WebControllerFactory> registry = (DriverRegistry<String, WebControllerFactory>) context.getBean("steviaDriverRegistry");
+
+
+        for (Entry<String, WebControllerFactory> entry : registry.getMappings().entrySet()) {
+            if (entry.getValue().getBeanName().equalsIgnoreCase(namesForType[0])) {
+                LOG.info("Factory from class detected : {}", entry.getKey());
+                WebControllerFactory factory = entry.getValue();
+                factory.initialize(context, controller);
+                return controller;
+            }
+        }
+        throw new IllegalStateException("Could not locate a factory for controller " + requestedControllerClass.getName() + " in this spring context!");
+    }
+
 
 }

--- a/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebControllerFactory.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebControllerFactory.java
@@ -40,6 +40,9 @@ import org.springframework.context.ApplicationContext;
 
 import com.persado.oss.quality.stevia.selenium.core.WebController;
 
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
 public interface WebControllerFactory {
 
 	/**
@@ -50,7 +53,7 @@ public interface WebControllerFactory {
 	 * @param controller
 	 * @return the returned bean is the provided, augmented with additional functionality
 	 */
-	 WebController initialize(ApplicationContext context, WebController controller);
+	 WebController initialize(ApplicationContext context, WebController controller) throws InterruptedException, ExecutionException, TimeoutException;
 	
 	/**
 	 * returns the name of bean as registered in the @id attribute in the stevia context <bean .../> construct.

--- a/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebDriverWebControllerFactoryImpl.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebDriverWebControllerFactoryImpl.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.selenium.core.controllers.factories;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *  
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
+ *
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -40,29 +40,31 @@ import com.persado.oss.quality.stevia.selenium.core.SteviaContext;
 import com.persado.oss.quality.stevia.selenium.core.WebController;
 import com.persado.oss.quality.stevia.selenium.core.controllers.SteviaWebControllerFactory;
 import com.persado.oss.quality.stevia.selenium.core.controllers.WebDriverWebController;
+import com.persado.oss.quality.stevia.selenium.loggers.SteviaLogger;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.concurrent.FutureUtils;
+import org.apache.flink.runtime.concurrent.ScheduledExecutor;
+import org.apache.flink.runtime.concurrent.ScheduledExecutorServiceAdapter;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.firefox.FirefoxDriver;
 import org.openqa.selenium.remote.Augmenter;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebDriver;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 
 public class WebDriverWebControllerFactoryImpl implements WebControllerFactory {
-    private static final Logger LOG = LoggerFactory.getLogger(WebDriverWebControllerFactoryImpl.class);
+    private static int remoteWebDriverRetry = 0;
+    private static final int MAX_RETRIES_REMOTE_WEB_DRIVER = 10;
+    private static final int RETRY_DELAY_REMOTE_WEB_DRIVER = 3000;
+
     @Override
-    public WebController initialize(ApplicationContext context, WebController controller) {
+    public WebController initialize(ApplicationContext context, WebController controller) throws InterruptedException, ExecutionException, TimeoutException {
         WebDriverWebController wdController = (WebDriverWebController) controller;
         WebDriver driver = null;
         /**
@@ -77,14 +79,11 @@ public class WebDriverWebControllerFactoryImpl implements WebControllerFactory {
         System.out.println("Initializing web driver with capabilities:" + SteviaContext.getCapabilities());
         if (SteviaContext.getParam("remote").compareTo(SteviaWebControllerFactory.TRUE) == 0) {
             final String wdHost = SteviaContext.getParam("rcUrl");
-            CompletableFuture<WebDriver> wd = CompletableFuture.supplyAsync(() -> getRemoteWebDriver(wdHost, capabilities));
-            try {
-                driver = wd.get(Integer.valueOf(SteviaContext.getParam("nodeTimeout")), TimeUnit.MINUTES);
-            } catch (InterruptedException | ExecutionException e) {
-                LOG.error(e.getMessage());
-            } catch (TimeoutException e) {
-                throw new RuntimeException("Timeout of " + Integer.valueOf(SteviaContext.getParam("nodeTimeout")) + " minutes reached waiting for a hub node to receive the request");
-            }
+            ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+            ScheduledExecutor executor = new ScheduledExecutorServiceAdapter(executorService);
+            CompletableFuture<WebDriver> wd = FutureUtils.retryWithDelay(() -> CompletableFuture.supplyAsync(() -> getRemoteWebDriver(wdHost, capabilities)), MAX_RETRIES_REMOTE_WEB_DRIVER, Time.milliseconds(RETRY_DELAY_REMOTE_WEB_DRIVER), executor);
+            driver = wd.get(Integer.parseInt(SteviaContext.getParam("nodeTimeout")), TimeUnit.MINUTES);
+            executorService.shutdown();
             ((RemoteWebDriver) driver).setFileDetector(new LocalFileDetector());
         } else {
             driver = getLocalDriver(capabilities);
@@ -113,9 +112,18 @@ public class WebDriverWebControllerFactoryImpl implements WebControllerFactory {
         WebDriver driver;
         Augmenter augmenter = new Augmenter(); // adds screenshot capability to a default webdriver.
         try {
+            if (remoteWebDriverRetry > 1) {
+                SteviaLogger.info("Retrying getting remoteWebDriver: Attempt " + remoteWebDriverRetry);
+            }
             driver = augmenter.augment(new RemoteWebDriver(new URL(rcUrl), desiredCapabilities));
         } catch (MalformedURLException e) {
+            SteviaLogger.error("Exception on getting remoteWebDriver: " + e.getMessage());
             throw new IllegalArgumentException(e.getMessage(), e);
+        } catch (Exception e) {
+            SteviaLogger.error("Exception on getting remoteWebDriver: " + e.getMessage());
+            throw e;
+        } finally {
+            remoteWebDriverRetry++;
         }
         return driver;
     }

--- a/src/main/java/com/persado/oss/quality/stevia/selenium/loggers/SteviaLogger.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/loggers/SteviaLogger.java
@@ -1,0 +1,56 @@
+package com.persado.oss.quality.stevia.selenium.loggers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Reporter;
+
+public class SteviaLogger extends Reporter {
+
+    static Logger LOG = LoggerFactory.getLogger("SteviaLogger");
+
+    static String PASS_COLOR = "lime";
+
+    static String WARN_COLOR = "orange";
+
+    static String ERROR_COLOR = "red";
+
+    /**
+     * Info message
+     *
+     * @param message the message
+     */
+    public static void info(String message) {
+        LOG.info(message);
+        log("<div class=\"testOutput\" style=\"font-size:1em\">" + message + "</div>");
+    }
+
+    /**
+     * Warning message
+     *
+     * @param message the message
+     */
+    public static void warn(String message) {
+        LOG.warn(message);
+        log("<div class=\"testOutput\" style=\"color:" + WARN_COLOR + "; font-size:1em;\">" + message + "</div>");
+    }
+
+    /**
+     * Error message
+     *
+     * @param message the message
+     */
+    public static void error(String message) {
+        LOG.error(message);
+        log("<div class=\"testOutput\" style=\"color:" + ERROR_COLOR + "; font-size:1em;\">" + message + "</div>");
+    }
+
+    /**
+     * Pass test message
+     *
+     * @param message
+     */
+    public static void pass(String message) {
+        LOG.info(message);
+        log("<div class=\"testOutput\" style=\"color:" + PASS_COLOR + "; font-size:1em;\">" + message + "</div>");
+    }
+}


### PR DESCRIPTION
### Changes by this PR
* Retrying mechanism in getRemoteWebDriver to handle cases with network glitches. example of this case:
![image](https://user-images.githubusercontent.com/16649224/103016330-8ec36a80-454a-11eb-9f0b-ce7be55f0024.png)
that after investigation is actually:
![image](https://user-images.githubusercontent.com/16649224/103016367-997dff80-454a-11eb-825c-46b57d00bc2e.png)
* Extra logs added for debugging
* New SteviaLogger added, in order to log both in console and in TestNG