### PR TITLE
ADD: Support for api only tests [QA-2984]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.persado.oss.quality.stevia</groupId>
 	<artifactId>stevia-core</artifactId>
-	<version>1.3.21-SNAPSHOT</version>
+	<version>1.3.22-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Stevia QA Framework - Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.persado.oss.quality.stevia</groupId>
 	<artifactId>stevia-core</artifactId>
-	<version>1.3.20-SNAPSHOT</version>
+	<version>1.3.21-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>Stevia QA Framework - Core</name>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,9 @@
 	</distributionManagement>
 
 	<scm>
-		<developerConnection>scm:git:git://github.com/Workable/stevia.git</developerConnection>
+		<url>https://github.com/Workable/stevia</url>
+		<connection>scm:git:git://github.com/Workable/stevia.git</connection>
+		<developerConnection>scm:git:git@github.com:Workable/stevia.git</developerConnection>
 		<tag>stevia-core-1.3.21</tag>
 	</scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 	</distributionManagement>
 
 	<scm>
-		<developerConnection>scm:git:https://github.com/Workable/stevia.git</developerConnection>
-		<tag>HEAD</tag>
+		<developerConnection>scm:git:git://github.com/Workable/stevia.git</developerConnection>
+		<tag>stevia-core-1.3.21</tag>
 	</scm>
 
 	<build>

--- a/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
+++ b/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.spring;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *  
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
+ *
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -51,10 +51,13 @@ import org.testng.xml.XmlSuite;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * The base class that is responsible for initializing Stevia contexts on start and shutting down on
@@ -108,11 +111,7 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
      */
     @BeforeSuite(alwaysRun = true)
     protected final void configureSuiteSettings(ITestContext testContext) throws Exception {
-        Map<String, String> parameters = new HashMap<>();
-        Set<String> propNames = System.getProperties().stringPropertyNames();
-        parameters.putAll(testContext.getSuite().getXmlSuite().getAllParameters());
-        propNames.forEach(p ->
-                parameters.put(p, System.getProperty(p)));
+        Map<String, String> parameters = configureParameters(testContext);
 
         setSuiteOutputDir(testContext.getSuite().getOutputDirectory());
 
@@ -142,6 +141,14 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         STEVIA_TEST_BASE_LOG.warn("*************************************************************************************");
         STEVIA_TEST_BASE_LOG.warn("*** SUITE initialisation phase END                                                ***");
         STEVIA_TEST_BASE_LOG.warn("*************************************************************************************");
+    }
+
+    private static Map<String, String> configureParameters(ITestContext testContext) {
+        Map<String, String> parameters = new HashMap<>();
+        Set<String> propNames = System.getProperties().stringPropertyNames();
+        parameters.putAll(testContext.getSuite().getXmlSuite().getAllParameters());
+        propNames.forEach(p -> parameters.put(p, System.getProperty(p)));
+        return parameters;
     }
 
     /**
@@ -193,6 +200,7 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         Map<String, String> parameters = testContext.getCurrentXmlTest().getParameters();
         testContext.getCurrentXmlTest().setParallel(XmlSuite.ParallelMode.getValidParallel(parameters.get("parallelSetup")));
         String parallelSetup = testContext.getSuite().getParallel();
+
         if (parallelSetup == null || parallelSetup.isEmpty() || parallelSetup.equalsIgnoreCase("false") || parallelSetup.equalsIgnoreCase("none") || parallelSetup.equalsIgnoreCase("tests")) {
 
             STEVIA_TEST_BASE_LOG.warn("*************************************************************************************");
@@ -310,11 +318,20 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         }
         SteviaContext.attachSpringContext(applicationContext);
 
-        WebController controller = SteviaWebControllerFactory.getWebController(applicationContext);
-        SteviaContext.setWebController(controller);
+        if (params.get("run.api.test") == null || params.get("run.api.test").equalsIgnoreCase("false")) {
+            configureWebController();
+        }
 
     }
 
+    private void configureWebController() throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException, NoSuchFieldException, IllegalAccessException {
+        if (applicationContext == null) {
+            throw new IllegalStateException("ApplicationContext not set - Stevia cannot continue");
+        }
+
+        WebController controller = SteviaWebControllerFactory.getWebController(applicationContext);
+        SteviaContext.setWebController(controller);
+    }
 
     /**
      * Stop RC server if it's running.

--- a/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
+++ b/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.spring;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *
+ *  
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *
+ *  
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *
+ *  
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *
+ *  
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *
+ *  
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE


### PR DESCRIPTION
## 📝 Description

- Extract new method that initialises the web controller conditionally, the web controller will be initialised only if not the run.api.test property is defined or is defined by is false. The newly introduced property run.api.tests provides the means to use stevia for running tests that do not require WebDriver support.

- Increase stevia pom version in order to create a new tag.

## 🛂 Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Just a miscellaneous chore

## ℹ️ Additional comments (if any)

{Please write here}