### PR TITLE
RMV: suite.init.context param conditions

### DIFF
--- a/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
+++ b/src/main/java/com/persado/oss/quality/stevia/spring/SteviaTestBase.java
@@ -116,22 +116,9 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         STEVIA_TEST_BASE_LOG.warn("*** SUITE initialisation phase START                                              ***");
         STEVIA_TEST_BASE_LOG.warn("*************************************************************************************");
 
-        boolean initContext = true;
-        if (parameters.get("suite.init.context") != null && parameters.get("suite.init.context").startsWith("false")) {
-            initContext = false;
-            STEVIA_TEST_BASE_LOG.info("suite initialisation via suiteInitialisation() override will not use a Stevia Context");
-        }
-
         // user code
         suiteInitialisation();
-        if (initContext) {
-            initializeStevia(parameters);
-        }
 
-        if (initContext) {
-            //stevia context clean
-            SteviaContext.clean();
-        }
         SteviaContext.registerParameters(SteviaContextSupport.getParameters(parameters));
         STEVIA_TEST_BASE_LOG.warn("*************************************************************************************");
         STEVIA_TEST_BASE_LOG.warn("*** SUITE initialisation phase END                                                ***");
@@ -163,8 +150,6 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         STEVIA_TEST_BASE_LOG.warn("***************************************************************************************");
         STEVIA_TEST_BASE_LOG.warn("*** suiteInitialisation() not overriden. Check your code and javadoc of method      ***");
         STEVIA_TEST_BASE_LOG.warn("*** NOTE: suiteInitialisation() by default has a SteviaContext to work with.        ***");
-        STEVIA_TEST_BASE_LOG.warn("***       If you don't want this (one extra browser to start/stop) define           ***");
-        STEVIA_TEST_BASE_LOG.warn("***       parameter 'suite.init.context' with value 'false'                         ***");
         STEVIA_TEST_BASE_LOG.warn("***************************************************************************************");
     }
 
@@ -182,8 +167,6 @@ public class SteviaTestBase extends AbstractTestNGSpringContextTests implements 
         STEVIA_TEST_BASE_LOG.warn("***************************************************************************************");
         STEVIA_TEST_BASE_LOG.warn("*** suiteInitialisation() not overriden. Check your code and javadoc of method      ***");
         STEVIA_TEST_BASE_LOG.warn("*** NOTE: suiteInitialisation() by default has a SteviaContext to work with.        ***");
-        STEVIA_TEST_BASE_LOG.warn("***       If you don't want this (one extra browser to start/stop) define           ***");
-        STEVIA_TEST_BASE_LOG.warn("***       parameter 'suite.init.context' with value 'false'                         ***");
         STEVIA_TEST_BASE_LOG.warn("***************************************************************************************");
     }
 


### PR DESCRIPTION
## 📝 Description

Remove redundant conditions for suite.init.context.
This will resolve issue regarding TestNG execution after merging TestNG 7 version

## 🛂 Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Just a miscellaneous chore

## ℹ️ Additional comments (if any)

-