### PR TITLE
migrates stevia to gar

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,9 @@
+
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>com.google.cloud.artifactregistry</groupId>
+    <artifactId>artifactregistry-maven-wagon</artifactId>
+    <version>2.2.1</version>
+  </extension>
+</extensions>

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ If you changed your mind, or something got wrong:
 - mvn release:rollback
 - mvn release:clean
 
-## Deploying a Snapshot to JFrog
+## Deploying a Snapshot to Artifactory
 
 - mvn clean deploy -DskipTests
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,18 +50,29 @@
 		</developer>
 	</developers>
 
-	<distributionManagement>
-		<repository>
-			<id>central</id>
-			<name>workable-releases</name>
-			<url>https://workable.jfrog.io/workable/maven-local</url>
-		</repository>
-		<snapshotRepository>
-			<id>snapshots</id>
-			<name>workable-snapshots</name>
-			<url>https://workable.jfrog.io/workable/maven-local</url>
-		</snapshotRepository>
-	</distributionManagement>
+  <distributionManagement>
+    <snapshotRepository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
+    </snapshotRepository>
+    <repository>
+      <id>artifact-registry</id>
+      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
+    </repository>
+  </distributionManagement>
+
+  <repositories>
+    <repository>
+      <id>artifact-virtual-registry</id>
+      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-virtual</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
 	<scm>
 		<url>https://github.com/Workable/stevia</url>
@@ -192,6 +203,11 @@
 		</plugins>
 
 		<extensions>
+		    <extension>
+        		<groupId>com.google.cloud.artifactregistry</groupId>
+        		<artifactId>artifactregistry-maven-wagon</artifactId>
+        		<version>2.2.0</version>
+      		</extension>
 			<extension>
 				<groupId>org.springframework.build</groupId>
 				<artifactId>aws-maven</artifactId>


### PR DESCRIPTION
This PR migrates stevia to `Google Artifact Registry`. 
In order for the authentication to succeed with the `google` plugin you must remove repo configuration from `settings.xml` 
If you want to use a Service account instead of your personal account you can just run the following:
```
export GOOGLE_APPLICATION_CREDENTIALS=<path_to_sa_file>

```

[SRE-5209](https://workable.atlassian.net/browse/SRE-5209)

[SRE-5209]: https://workable.atlassian.net/browse/SRE-5209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ