### PR TITLE
Increase read timeout

### DIFF
--- a/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebDriverWebControllerFactoryImpl.java
+++ b/src/main/java/com/persado/oss/quality/stevia/selenium/core/controllers/factories/WebDriverWebControllerFactoryImpl.java
@@ -7,21 +7,21 @@ package com.persado.oss.quality.stevia.selenium.core.controllers.factories;
  * Copyright (C) 2013 - 2014 Persado
  * %%
  * Copyright (c) Persado Intellectual Property Limited. All rights reserved.
- *  
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
- *  
+ *
  * * Redistributions of source code must retain the above copyright notice, this
  * list of conditions and the following disclaimer.
- *  
+ *
  * * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- *  
+ *
  * * Neither the name of the Persado Intellectual Property Limited nor the names
  * of its contributors may be used to endorse or promote products derived from
  * this software without specific prior written permission.
- *  
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -41,7 +41,10 @@ import com.persado.oss.quality.stevia.selenium.core.WebController;
 import com.persado.oss.quality.stevia.selenium.core.controllers.SteviaWebControllerFactory;
 import com.persado.oss.quality.stevia.selenium.core.controllers.WebDriverWebController;
 import com.persado.oss.quality.stevia.selenium.loggers.SteviaLogger;
-import org.openqa.selenium.*;
+import org.openqa.selenium.Capabilities;
+import org.openqa.selenium.SessionNotCreatedException;
+import org.openqa.selenium.UsernameAndPassword;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeDriver;
@@ -174,12 +177,13 @@ public class WebDriverWebControllerFactoryImpl implements WebControllerFactory {
             readTimeout.setAccessible(true);
             HttpCommandExecutor executor = (HttpCommandExecutor) ((RemoteWebDriver) driver).getCommandExecutor();
             JdkHttpClient client = (JdkHttpClient) clientOfExecutor.get(executor);
-            readTimeout.set(client, Duration.ofSeconds(60));
+            readTimeout.set(client, Duration.ofSeconds(120));
         }
     }
 
     /**
      * Set up the correct options in case of Gridlastic
+     *
      * @param capabilities
      * @param wdHost
      */


### PR DESCRIPTION
## 📝 Description

This PR aims to mitigate an issue observed after moving to the custom grid. The issue is exhibited only when multiple tests run in parallel and a sendKeys command is executed with an input of ~1.8K chars. The generated video recording shows that the initial operation is completed after ~80s, but due to the low read timeout the operation is retried, ultimately resulting in a `org.openqa.selenium.TimeoutException`.

![Screenshot 2024-04-16 at 4 26 53 PM](https://github.com/Workable/stevia/assets/21123613/40c34d8b-7535-4040-a4c7-c9a77d133aff)

## 🛂 Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Just a miscellaneous chore