### PR TITLE
Bulk dependency updates and preparation for Java 17

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,6 +4,6 @@
   <extension>
     <groupId>com.google.cloud.artifactregistry</groupId>
     <artifactId>artifactregistry-maven-wagon</artifactId>
-    <version>2.2.1</version>
+    <version>2.2.3</version>
   </extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -50,29 +50,29 @@
 		</developer>
 	</developers>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>artifact-registry</id>
-      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
-    </snapshotRepository>
-    <repository>
-      <id>artifact-registry</id>
-      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
-    </repository>
-  </distributionManagement>
+	<distributionManagement>
+    	<snapshotRepository>
+			<id>artifact-registry</id>
+			<url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
+		</snapshotRepository>
+		<repository>
+			<id>artifact-registry</id>
+			<url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-local</url>
+		</repository>
+	</distributionManagement>
 
-  <repositories>
-    <repository>
-      <id>artifact-virtual-registry</id>
-      <url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-virtual</url>
-      <releases>
-        <enabled>true</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+	<repositories>
+		<repository>
+			<id>artifact-virtual-registry</id>
+			<url>artifactregistry://us-east4-maven.pkg.dev/staging-artifacts-786a/maven-virtual</url>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</repository>
+	</repositories>
 
 	<scm>
 		<url>https://github.com/Workable/stevia</url>
@@ -89,39 +89,39 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-clean-plugin</artifactId>
-					<version>2.5</version>
+					<version>3.4.0</version>
 				</plugin>
 				<!-- Compiles Java sources -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.10.1</version>
+					<version>3.13.0</version>
 					<inherited>true</inherited>
 					<configuration>
-						<release>11</release>
+						<release>17</release>
 					</configuration>
 				</plugin>
 
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
-					<version>2.7</version>
+					<version>3.1.3</version>
 				</plugin>
 				<!-- Build a JAR from the current project -->
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-jar-plugin</artifactId>
-					<version>2.4</version>
+					<version>3.4.2</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-release-plugin</artifactId>
-					<version>2.5.3</version>
+					<version>3.1.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.1</version>
+					<version>3.10.0</version>
 					<configuration>
 						<failOnError>false</failOnError>
 					</configuration>
@@ -133,7 +133,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.4</version>
+				<version>3.3.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -146,7 +146,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.14</version>
+				<version>3.5.0</version>
 				<!-- <configuration> <skipTests>false</skipTests> </configuration> -->
 				<executions>
 					<execution>
@@ -164,7 +164,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>license-maven-plugin</artifactId>
-				<version>1.6</version>
+				<version>2.4.0</version>
 				<configuration>
 					<verbose>false</verbose>
 					<organizationName>Persado Intellectual Property Limited</organizationName>
@@ -206,7 +206,7 @@
 		    <extension>
         		<groupId>com.google.cloud.artifactregistry</groupId>
         		<artifactId>artifactregistry-maven-wagon</artifactId>
-        		<version>2.2.0</version>
+        		<version>2.2.3</version>
       		</extension>
 			<extension>
 				<groupId>org.springframework.build</groupId>
@@ -227,21 +227,19 @@
 		<dependency>
 			<groupId>org.jsoup</groupId>
 			<artifactId>jsoup</artifactId>
-			<version>1.7.3</version>
+			<version>1.18.1</version>
 		</dependency>
 		<dependency>
 			<groupId>us.codecraft</groupId>
 			<artifactId>xsoup</artifactId>
-			<version>0.3.0</version>
+			<version>0.3.7</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime_2.12</artifactId>
-			<version>1.12.0</version>
+			<version>1.13.6</version>
 		</dependency>
-
 
 		<!-- Jetty HTTP Client -->
 		<dependency>
@@ -289,7 +287,7 @@
 		<dependency>
 			<groupId>com.google.inject</groupId>
 			<artifactId>guice</artifactId>
-			<version>3.0</version>
+			<version>7.0.0</version>
 		</dependency>
 
 		<dependency>
@@ -301,7 +299,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>23.0</version>
+			<version>33.3.0-jre</version>
 		</dependency>
 
 		<!-- Selenium Server Standalone -->
@@ -320,9 +318,8 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
-			<version>2.3</version>
+			<version>2.13.0</version>
 		</dependency>
-
 
 		<!-- OBTAINING SPRING RELEASES FROM MANEN CENTRAL -->
 
@@ -391,21 +388,19 @@
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjrt</artifactId>
-			<version>1.7.4</version>
+			<version>1.9.22.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.aspectj</groupId>
 			<artifactId>aspectjweaver</artifactId>
-			<version>1.7.4</version>
+			<version>1.9.22.1</version>
 		</dependency>
 
 		<dependency>
-			<groupId>javassist</groupId>
+			<groupId>org.javassist</groupId>
 			<artifactId>javassist</artifactId>
-			<version>3.12.1.GA</version>
+			<version>3.24.0-GA</version>
 		</dependency>
-
-
 
 		<!-- Support for testing Spring applications with tools such as JUnit and
 			TestNG This artifact is generally always defined with a 'test' scope for
@@ -430,20 +425,20 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>1.7.5</version>
+			<version>2.0.16</version>
 		</dependency>
+
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.1.0</version>
+			<version>1.5.8</version>
 			<scope>test</scope>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.fusesource.mqtt-client</groupId>
 			<artifactId>mqtt-client</artifactId>
-			<version>1.3</version>
+			<version>1.16</version>
 		</dependency>
 
 		<dependency>
@@ -455,7 +450,7 @@
 
 	<!-- Shared version number properties -->
 	<properties>
-		<org.springframework.version>5.0.2.RELEASE</org.springframework.version>
+		<org.springframework.version>5.3.39</org.springframework.version>
 		<selenium.version>4.23.1</selenium.version>
 		<appium.version>9.2.3</appium.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## 📝 Description

The PR includes the following items:
- Condense the xml, and remove double and triple empty lines
- Update plugins version to support Java 17
- Update maven plugins
- Target Java 17
- Update artifactregistry-maven-wagon
- Bulk dependency updates

## 🛂 Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## ℹ️ Additional comments (if any)

Although this isn't strictly a breaking change, it has been marked as such to avoid possible errors.